### PR TITLE
feat: add pkg-size to website, update default options

### DIFF
--- a/package.json
+++ b/package.json
@@ -241,7 +241,7 @@
                             "[Npm View](https://npmview.vercel.app/${packageNameAtVersion})",
                             "[Npm Trends](https://npmtrends.com/${packageName})",
                             "[Npm Graph](https://npmgraph.js.org/?q=${packageNameAtVersion})",
-                            "[Bundlephobia](https://bundlephobia.com/package/${packageNameAtVersion}))",
+                            "[Bundlephobia](https://bundlephobia.com/package/${packageNameAtVersion})",
                             "[pkg-size](https://pkg-size.dev/${packageNameAtVersion})"
                         ]
                     },

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
                     },
                     "package-manager-enhancer.enablePackageJsonDependenciesCodeLens": {
                         "type": "boolean",
-                        "default": true
+                        "default": false
                     },
                     "package-manager-enhancer.packageJsonDependenciesCodeLens.dependenciesNodePaths": {
                         "markdownDescription": "display dependencies codeLens more than the default key `dependencies`, for example: `devDependencies`, `pnpm.overrides`",
@@ -171,7 +171,11 @@
                             "type": "string"
                         },
                         "default": [
-                            "dependencies"
+                            "dependencies",
+                            "peerDependencies",
+                            "devDependencies",
+                            "resolutions",
+                            "pnpm.overrides"
                         ]
                     },
                     "package-manager-enhancer.packageJsonDependenciesCodeLens.searchDependenciesFileExtensions": {
@@ -241,7 +245,6 @@
                             "[Npm View](https://npmview.vercel.app/${packageNameAtVersion})",
                             "[Npm Trends](https://npmtrends.com/${packageName})",
                             "[Npm Graph](https://npmgraph.js.org/?q=${packageNameAtVersion})",
-                            "[Bundlephobia](https://bundlephobia.com/package/${packageNameAtVersion})",
                             "[pkg-size](https://pkg-size.dev/${packageNameAtVersion})"
                         ]
                     },

--- a/package.json
+++ b/package.json
@@ -240,7 +240,9 @@
                             "builtin:repository",
                             "[Npm View](https://npmview.vercel.app/${packageNameAtVersion})",
                             "[Npm Trends](https://npmtrends.com/${packageName})",
-                            "[Npm Graph](https://npmgraph.js.org/?q=${packageNameAtVersion})"
+                            "[Npm Graph](https://npmgraph.js.org/?q=${packageNameAtVersion})",
+                            "[Bundlephobia](https://bundlephobia.com/package/${packageNameAtVersion}))",
+                            "[pkg-size](https://pkg-size.dev/${packageNameAtVersion})"
                         ]
                     },
                     "package-manager-enhancer.packageHoverTooltip.badges": {


### PR DESCRIPTION
BTW, what do you think about changing some default configurations to the following:

```json
{
  "package-manager-enhancer.enablePackageJsonDependenciesCodeLens": false,
  "package-manager-enhancer.packageJsonDependenciesCodeLens.dependenciesNodePaths": [
    "dependencies",
    "devDependencies"
  ],
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added new links in the package information: [Npm Graph](https://npmgraph.js.org/?q=${packageNameAtVersion}), [pkg-size](https://pkg-size.dev/${packageNameAtVersion}), and [Bundlephobia](https://bundlephobia.com/package/${packageNameAtVersion}). 

These links provide additional insights into package dependencies and size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->